### PR TITLE
Align with TPEN messaging contract — accept TPEN_CONTEXT, emit NAVIGATE_TO_LINE

### DIFF
--- a/message-handler.js
+++ b/message-handler.js
@@ -21,67 +21,48 @@ export class MessageHandler {
     }
 
     /**
-     * Handle incoming messages from parent window
+     * Handle incoming messages from parent window. Page-Viewer accepts the
+     * lean TPEN_CONTEXT boot payload (canvas/manifest/annotationPage URIs +
+     * currentLineId) and UPDATE_CURRENT_LINE deltas. Auth is not used.
      * @param {MessageEvent} event - The message event
      */
     handleMessage(event) {
         if (!event.data?.type) return
 
         switch (event.data.type) {
-            // TPEN standard message types
             case "TPEN_CONTEXT":
-                // Receive context from parent (project, page, canvas, etc.)
                 this.#handleTPENContext(event.data)
                 break
 
-            case "SELECT_ANNOTATION":
-            case "NAVIGATE_TO_LINE":
-            case "CURRENT_LINE_INDEX":
-            case "RETURN_LINE_ID":
-                // Standard navigation message - extract line ID and navigate
-                this.#handleLineNavigation(event.data)
+            case "UPDATE_CURRENT_LINE":
+                this.#handleLineNavigation(event.data.currentLineId)
                 break
 
-            // Legacy/custom canvas loading message types (backward compatible)
-            case "MANIFEST_CANVAS_ANNOTATIONPAGE_ANNOTATION":
-            case "CANVAS_ANNOTATIONPAGE_ANNOTATION":
-            case "MANIFEST_CANVAS_ANNOTATIONPAGE":
-            case "CANVAS_ANNOTATIONPAGE":
-            case "MANIFEST_CANVAS":
-            case "CANVAS":
-                this.pageViewer.loadPage(event.data.canvas, event.data.manifest, event.data.annotationPage, event.data.annotation)
-                break
-
-            case "REQUEST_TPEN_ID_TOKEN":
-                // Page-Viewer doesn't need auth
-                break
             default:
-                console.warn("Unknown message type:", event.data.type)
+                break
         }
     }
 
     /**
-     * Handle TPEN context message (informational - parent sharing context with viewer)
+     * Handle TPEN context message. Loads the active canvas and highlights
+     * the current line if one is set.
      * @param {Object} data - TPEN context data
      */
     #handleTPENContext(data) {
-        // Store context if needed for future interactions
-        // Page-Viewer can use this to maintain state alignment with parent
         if (data.canvas) {
-            // If parent explicitly sends a canvas, ensure we're viewing it
-            this.pageViewer.loadPage(data.canvas)
+            this.pageViewer.loadPage(data.canvas, data.manifest, data.annotationPage, data.currentLineId)
+        }
+        if (data.currentLineId) {
+            this.pageViewer.uiManager?.highlightAnnotation?.(data.currentLineId)
         }
     }
 
     /**
-     * Handle line navigation from parent (SELECT_ANNOTATION, NAVIGATE_TO_LINE, etc.)
-     * @param {Object} data - Message data with lineId/lineid/annotation field
+     * Highlight the active line on the canvas overlay.
+     * @param {string|null} currentLineId - Full line IRI or null
      */
-    #handleLineNavigation(data) {
-        // Support both ID-based and index-based navigation payloads.
-        const lineRef = data.lineId ?? data.lineid ?? data.annotation ?? data.lineIndex ?? data.currentLineIndex
-        if (lineRef === undefined || lineRef === null) return
-
-        this.pageViewer.uiManager?.highlightAnnotation?.(lineRef)
+    #handleLineNavigation(currentLineId) {
+        if (!currentLineId) return
+        this.pageViewer.uiManager?.highlightAnnotation?.(currentLineId)
     }
 }

--- a/message-handler.js
+++ b/message-handler.js
@@ -35,6 +35,10 @@ export class MessageHandler {
                 break
 
             case "UPDATE_CURRENT_LINE":
+                if (!('currentLineId' in event.data)) {
+                    console.warn('[page-viewer] UPDATE_CURRENT_LINE missing currentLineId', event.data)
+                    break
+                }
                 this.#handleLineNavigation(event.data.currentLineId)
                 break
 
@@ -60,6 +64,6 @@ export class MessageHandler {
      */
     #handleLineNavigation(currentLineId) {
         if (!currentLineId) return
-        this.pageViewer.uiManager?.highlightAnnotation?.(currentLineId)
+        this.pageViewer.uiManager.highlightAnnotation(currentLineId)
     }
 }

--- a/message-handler.js
+++ b/message-handler.js
@@ -44,17 +44,14 @@ export class MessageHandler {
     }
 
     /**
-     * Handle TPEN context message. Loads the active canvas and highlights
-     * the current line if one is set.
+     * Handle TPEN context message. Loads the active canvas; the current line
+     * (if any) rides along on `loadPage`, which highlights the matching
+     * overlay box once annotations have rendered.
      * @param {Object} data - TPEN context data
      */
     #handleTPENContext(data) {
-        if (data.canvas) {
-            this.pageViewer.loadPage(data.canvas, data.manifest, data.annotationPage, data.currentLineId)
-        }
-        if (data.currentLineId) {
-            this.pageViewer.uiManager?.highlightAnnotation?.(data.currentLineId)
-        }
+        if (!data.canvas) return
+        this.pageViewer.loadPage(data.canvas, data.manifest, data.annotationPage, data.currentLineId)
     }
 
     /**

--- a/ui-manager.js
+++ b/ui-manager.js
@@ -242,9 +242,8 @@ export class UIManager {
         
         // Notify parent window
         window.parent?.postMessage({
-            type: "RETURN_LINE_ID",
-            lineid,
-            lineIndex: index
+            type: "NAVIGATE_TO_LINE",
+            lineId: lineid
         }, "*")
     }
 


### PR DESCRIPTION
## Summary

Align Page-Viewer with the canonical TPEN messaging contract. Replace the alias-soup switch (`MANIFEST_CANVAS_*`, `CANVAS_*`, `SELECT_ANNOTATION`, `CURRENT_LINE_INDEX`, `RETURN_LINE_ID`) with the two messages we actually use: `TPEN_CONTEXT` (boot) and `UPDATE_CURRENT_LINE` (line-nav delta). Outbound, replace `RETURN_LINE_ID` with `NAVIGATE_TO_LINE`. The full contract is defined in CenterForDigitalHumanities/TPEN-interfaces#564.

## Changes

- `message-handler.js`
  - `handleMessage` switch reduced to two cases: `TPEN_CONTEXT`, `UPDATE_CURRENT_LINE`. Unknown types now silently ignored (was a `console.warn`).
  - `#handleTPENContext` calls `loadPage(canvas, manifest, annotationPage, currentLineId)` — the existing 4-arg signature highlights the matching overlay box internally once annotations render.
  - **Race fix (commit `ff25235`):** removed the redundant `highlightAnnotation(currentLineId)` follow-up. `loadPage` is async and the sync follow-up hit an empty DOM, so the highlight wasn't reliably applied on boot.
  - `#handleLineNavigation` simplified to a single param (the new contract carries `currentLineId`, no alias hunting).
- `ui-manager.js`
  - Outbound message renamed `RETURN_LINE_ID` → `NAVIGATE_TO_LINE`; field `lineid` → `lineId`. Dropped the redundant `lineIndex` field — the parent matches by id.

## Coordinated cut

Hard cut, all PRs must merge together. Full contract and other PRs:

- TPEN-interfaces (authority): https://github.com/CenterForDigitalHumanities/TPEN-interfaces/pull/564
- TPEN-services: https://github.com/CenterForDigitalHumanities/TPEN-services/pull/519
- Preview-Transcription: https://github.com/CenterForDigitalHumanities/Preview-Transcription/pull/6
- Line-Breaking: https://github.com/CenterForDigitalHumanities/Line-Breaking/pull/2
- Compare-Pages: https://github.com/CenterForDigitalHumanities/Compare-Pages/pull/3
- TPEN-Prompts: https://github.com/CenterForDigitalHumanities/TPEN-Prompts/pull/16

## Test plan

Developer-validated locally on 2026-05-08 against CenterForDigitalHumanities/TPEN-interfaces#564 + CenterForDigitalHumanities/TPEN-services#519 on `:4000` / `:3012`:

- [x] In TPEN-interfaces (`jekyll s`), add Page-Viewer to a project's tools. Open `/transcribe`.
- [x] Iframe loads → canvas image renders, all overlay boxes draw, the active line is highlighted on first paint without a click. Race fix `ff25235` confirmed.
- [x] Click a line in the parent transcription block → Page-Viewer highlights the matching overlay box (`UPDATE_CURRENT_LINE`).
- [x] Click a box in Page-Viewer → parent transcription advances to that line (`NAVIGATE_TO_LINE { lineId }`).
- [x] DevTools: exactly one inbound `TPEN_CONTEXT` per iframe load, one inbound `UPDATE_CURRENT_LINE` per parent-side line nav, one outbound `NAVIGATE_TO_LINE` per click. No legacy aliases observed.